### PR TITLE
wrong handle caused infinite loop fix

### DIFF
--- a/source/ClientCurl.cpp
+++ b/source/ClientCurl.cpp
@@ -140,7 +140,10 @@ void ClientCurl::mainClientLoop() {
   std::unique_lock<std::mutex> client_lock(_client_mutex);
   while (true) {
     // launch any waiting requests
-    curl_multi_perform(_curl, &active_requests);
+    if (curl_multi_perform(_curl, &active_requests)) {
+        fprintf(stderr, "E: curl_multi_perform\n");
+        active_requests = 0;
+    }
 
     // read any messages that are ready
     size_t msg_count = 0;


### PR DESCRIPTION
According to the code of curl in case of failed handle the active_requests will not be updated. Also it causes infinite loop. 